### PR TITLE
add a fallback backend to avoid errors on invalid backend

### DIFF
--- a/brightness.lua
+++ b/brightness.lua
@@ -131,6 +131,23 @@ backends.xbacklight = {
     end,
 }
 
+------------------------------------------
+-- Backend: fallback (doesn't do anything)
+------------------------------------------
+
+backends.fallback = {
+    cmd = "",
+    supported = function()
+        return true
+    end,
+    get = function() end,
+    set = function() end,
+    up = function() end,
+    down = function() end,
+    to_percent = function() end,
+    from_percent = function() end,
+    max = function() end,
+}
 
 ------------------------------------------
 -- Volume control interface
@@ -159,6 +176,7 @@ function vcontrol:init(args)
             backend = backends.xbacklight
         else
             warning("Neither brightnessctl nor xbacklight seems to work")
+            backend = backends.fallback -- to avoid errors
         end
     end
 


### PR DESCRIPTION
This is not a perfect implementation, but allows errors to be avoided when no valid backend is installed.
