### PR TITLE
set self.widget to an empty textbox instead of nil

### DIFF
--- a/brightness.lua
+++ b/brightness.lua
@@ -168,7 +168,7 @@ function vcontrol:init(args)
     self.levels = args.levels or {1, 25, 50, 75, 100}
 
     if backend == nil then
-        self.widget = nil
+        self.widget = wibox.widget.textbox()
         self.timer = nil
     else
         self.widget = wibox.widget.textbox()


### PR DESCRIPTION
When backend == nil, this sets self.widget to an empty `wibox.widget.textbox`. This allows the user to handle it in the same way as if it was a fully functional widget, without causing errors when including it in other widgets/wiboxes.
