### PR TITLE
Brightnessctl refactor

### DIFF
--- a/brightness.lua
+++ b/brightness.lua
@@ -224,3 +224,4 @@ end
 return setmetatable(vcontrol, {
   __call = vcontrol.new,
 })
+-- vim: set ts=4 sw=4 et:

--- a/brightness.lua
+++ b/brightness.lua
@@ -169,33 +169,35 @@ function vcontrol:init(args)
             awful.button({ }, 5, function() self:down(1) end)
         ))
 
-        self.timer = timer({ timeout = args.timeout or 3 })
-        self.timer:connect_signal("timeout", function() self:update() end)
-        self.timer:start()
-        self:update()
+        self.timer = timer({
+            timeout = args.timeout or 3,
+            callback = function(...) self:update(...) end,
+            autostart = true,
+            call_now = true
+        })
     end
 
     return self
 end
 
-function vcontrol:update()
-    self.backend:get(function(value)
+function vcontrol:update(opt_value)
+    local done = function(value)
         local brightness = math.floor(0.5 + value)
         self.widget:set_text(string.format(" [%3d] ", brightness))
-        return brightness
-    end)
+    end
+    if opt_value then done(opt_value) else self.backend:get(done) end
 end
 
 function vcontrol:set(brightness, callback)
-    self.backend:set(brightness, callback or function() self:update() end)
+    self.backend:set(brightness, callback or function(...) self:update(...) end)
 end
 
 function vcontrol:up(step, callback)
-    self.backend:up(step or self.step, callback or function() self:update() end)
+    self.backend:up(step or self.step, callback or function(...) self:update(...) end)
 end
 
 function vcontrol:down(step, callback)
-    self.backend:down(step or self.step, callback or function() self:update() end)
+    self.backend:down(step or self.step, callback or function(...) self:update(...) end)
 end
 
 function vcontrol:toggle()

--- a/brightness.lua
+++ b/brightness.lua
@@ -86,7 +86,9 @@ backends.brightnessctl = {
     end,
 
     down = function(self, step, callback)
-        exec({ self.cmd, "--class=backlight", "-m", "set", step .. "%-" }, callback)
+        exec({ self.cmd, "--class=backlight", "-m", "set", step .. "%-" }, function(output)
+            callback(self:parse_output(output))
+        end)
     end,
 }
 

--- a/brightness.lua
+++ b/brightness.lua
@@ -80,13 +80,13 @@ backends.brightnessctl = {
     end,
 
     up = function(self, step, callback)
-    		exec({ self.cmd, "--class=backlight", "-m", "set", step .. "%+" }, function(output)
+        exec({ self.cmd, "--class=backlight", "-m", "set", step .. "%+" }, function(output)
             callback(self:parse_output(output))
         end)
     end,
 
     down = function(self, step, callback)
-    		exec({ self.cmd, "--class=backlight", "-m", "set", step .. "%-" }, callback)
+        exec({ self.cmd, "--class=backlight", "-m", "set", step .. "%-" }, callback)
     end,
 }
 

--- a/brightness.lua
+++ b/brightness.lua
@@ -187,7 +187,11 @@ function vcontrol:update(opt_value)
         local brightness = math.floor(0.5 + value)
         self.widget:set_text(string.format(" [%3d] ", brightness))
     end
-    if opt_value then done(opt_value) else self.backend:get(done) end
+    if opt_value and string.match(opt_value, "%S+") then
+        done(opt_value)
+    else
+        self.backend:get(done)
+    end
 end
 
 function vcontrol:set(brightness, callback)

--- a/brightness.lua
+++ b/brightness.lua
@@ -182,15 +182,16 @@ function vcontrol:init(args)
     return self
 end
 
+function vcontrol:set_text(value)
+    local brightness = math.floor(0.5 + value)
+    self.widget:set_text(string.format(" [%3d] ", brightness))
+end
+
 function vcontrol:update(opt_value)
-    local done = function(value)
-        local brightness = math.floor(0.5 + value)
-        self.widget:set_text(string.format(" [%3d] ", brightness))
-    end
     if opt_value and string.match(opt_value, "%S+") then
-        done(opt_value)
+        self:set_text(opt_value)
     else
-        self.backend:get(done)
+        self.backend:get(function(...) self:set_text(...) end)
     end
 end
 


### PR DESCRIPTION
Brightnessctl outputs information about the new state on each command. Then, we proceed to call `brightnessctl get`, ignoring this information.
This PR uses the `-m` (`--machine-readable`) flag of `brightnessctl` to get the output and skip spawning an extra process.
Because this must now be *passed to* `vcontrol:update`, some slight refactoring was required to *permit* an *optional* argument containing the new brightness.